### PR TITLE
Update lightproxy.rb

### DIFF
--- a/lightproxy.rb
+++ b/lightproxy.rb
@@ -11,34 +11,15 @@ class Lightproxy < Formula
   end
 
   def post_install
-    system "lightproxy", "init"
+    system "#{bin}/lightproxy", "init"
   end
 
-  plist_options manual: "lightproxy"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>KeepAlive</key>
-          <true/>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>ProgramArguments</key>
-          <array>
-            <string>#{opt_bin}/lightproxy</string>
-          </array>
-          <key>RunAtLoad</key>
-          <true />
-          <key>StandardErrorPath</key>
-          <string>/dev/null</string>
-          <key>StandardOutPath</key>
-          <string>/dev/null</string>
-        </dict>
-      </plist>
-    EOS
+  service do
+    run [opt_bin/"lightproxy"]
+    keep_alive true
+    working_dir HOMEBREW_PREFIX
+    log_path var/"log/lightproxy.log"
+    error_log_path var/"log/lightproxy.log"
   end
 
   test do


### PR DESCRIPTION
Plist is deprecated, getting the below error while running

`brew install octavore/tools/lightproxy`

```Error: octavore/tools/lightproxy: undefined method `plist_options' for class Formulary::FormulaNamespaced8ffd7b0d80fd98c2ff1c7aa8d004a70100b1c4ec234ad0eccae2133f88f33f6::Lightproxy```

updated to use brew services